### PR TITLE
added invariant case to store_mnesia:delete/2

### DIFF
--- a/src/store_mnesia.erl
+++ b/src/store_mnesia.erl
@@ -37,7 +37,8 @@ put(Record) -> put([Record]).
 delete(Tab, Key) ->
     case mnesia:activity(context(),fun()-> mnesia:delete({Tab, Key}) end) of
         {aborted,Reason} -> {error,Reason};
-        {atomic,_Result} -> ok end.
+        {atomic,_Result} -> ok;
+        X -> X end.
 count(RecordName) -> mnesia:table_info(RecordName, size).
 all(R) -> lists:flatten(many(fun() -> L= mnesia:all_keys(R), [ mnesia:read({R, G}) || G <- L ] end)).
 next_id(RecordName, Incr) -> mnesia:dirty_update_counter({id_seq, RecordName}, Incr).


### PR DESCRIPTION
During kvs:remove/2 call with mnesia as a backend I got error.
At store_mnesia:delete/2 line 38 case expression does not match any pattern.

`mnesia:activity(context(),fun()-> mnesia:delete({Tab, Key}) end)` returns just `ok`