### PR TITLE
Replace deprecated erlang:now on os:timestamp

### DIFF
--- a/src/kvs.erl
+++ b/src/kvs.erl
@@ -269,4 +269,4 @@ dump() ->
          mnesia:table_info(Name,storage_type),
          mnesia:table_info(Name,memory),
          mnesia:table_info(Name,size)]) || #table{name=Name} <- kvs:tables()],
-     io:format("Snapshot taken: ~p~n",[calendar:now_to_datetime(now())]).
+     io:format("Snapshot taken: ~p~n",[calendar:now_to_datetime(os:timestamp())]).

--- a/src/store/store_kai.erl
+++ b/src/store/store_kai.erl
@@ -19,7 +19,7 @@ put(Record) -> kai_put(Record).
 
 kai_put(Record) ->
     Data = #data{key = element(2,Record), bucket = table_to_num(element(1,Record)),
-        last_modified = now(), checksum = erlang:md5(term_to_binary(Record)),
+        last_modified = os:timestamp(), checksum = erlang:md5(term_to_binary(Record)),
         vector_clocks = vclock:fresh(), value = Record },
     kai_store:put(Data).
 


### PR DESCRIPTION
Deprecated BIF. See the "Time and Time Correction in Erlang" chapter of the ERTS
User's Guide for more information.