### PR TITLE
Next iterator support

### DIFF
--- a/include/api.hrl
+++ b/include/api.hrl
@@ -8,7 +8,7 @@
 -export([start/0,stop/0]).                                        % service
 -export([destroy/0,join/0,join/1,init/2]).                        % schema change
 -export([modules/0,containers/0,tables/0,table/1,version/0]).     % meta info
--export([create/1,add/1,link/1,remove/2]).                        % chain ops
+-export([create/1,add/1,link/1,unlink/1,remove/2]).               % chain ops
 -export([put/1,delete/2,next_id/2]).                              % raw ops
 -export([get/2,get/3,index/3]).                                   % read ops
 -export([load_db/1,save_db/1]).                                   % import/export
@@ -37,7 +37,9 @@
 % chain ops
 
 -spec create(Container :: atom()) -> integer().
--spec add(Record :: tuple()) -> {ok,tuple()} | {error,exist} | {error,no_container}.
+-spec add(Record :: tuple()) -> {ok,tuple()} | {error,exist} | {error,no_container} | {error,just_added} | {aborted,any()}.
+-spec link(Record :: tuple()) -> {ok,tuple()} | {error, not_found} | {error,no_container} | {error,just_added}.
+-spec unlink(Record :: tuple()) -> {ok,tuple()} | {error,no_container}.
 -spec remove(Tab :: atom(), Key :: any()) -> ok | {error,any()}.
 
 % raw ops

--- a/include/kvs.hrl
+++ b/include/kvs.hrl
@@ -1,7 +1,7 @@
 -ifndef(KVS_HRL).
 -define(KVS_HRL, true).
 
--define(CONTAINER, id=[], top=[], count=0).
+-define(CONTAINER, id=[], top=[], rear=[], count=0).
 -define(ITERATOR(Container), id=[], container=Container, feed_id=[], prev=[], next=[], feeds=[]).
 
 -record(id_seq,    {thing, id}).


### PR DESCRIPTION
## Scheme
* **WARNING!** Modified scheme for all containers tables (`feed`, etc.)
```erlang
-define(CONTAINER, id=[], top=[], 
    rear=[], % <-- this
    count=0).
```

## Overview
* Allow `#iterator.next` direction for `kvs:fold/6`
* Add `unlink/1` (remove link with the feed) into API
* Specs for `add/1`, `link/1`, `unlink/1`

## Migration (mnesia only)

1. Update kvs
2. Run **ONLY** mnesia application (without kvs, n2o, etc.)
3. Modify the following code if necessary, and launch `update_schema/1` for all of container tables (`feed`, etc.). For database containing millions of records the procedure can be work out more than 1 hour!
```erlang
-include_lib("kvs/include/kvs.hrl").

update_schema(Container) ->
    mnesia:transform_table(Container,fun
        ({C, Id, Top, Count, Aclver}) ->
            Tab = case Id of {A, _} -> A; _ -> Id end,
            Fun = fun(Last, _) -> element(2, Last) end,
            Rear = kvs:fold(Fun, [], Tab, Top, Count, #iterator.prev),
            {C, Id, Top, Rear, Count, Aclver};
        (C) -> C
    end, [id, top, rear, count, aclver]).
```