### PR TITLE
export db/0 needed by kvs_stream:db

### DIFF
--- a/src/kvs.erl
+++ b/src/kvs.erl
@@ -19,6 +19,7 @@
 -include("backend.hrl").
 
 -export([dump/0,
+         db/0,
          metainfo/0,
          ensure/1,
          ensure/2,


### PR DESCRIPTION
might need to be defined instead in one of the .hrl files?